### PR TITLE
Installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Simple extension for hyper terminal that maintains the current working directory when opening new tabs.
 
+## Installation
+
+Simply run `hyper i hyper-samewd` if you have added hyper to path.
+
+or open `~/.hyper.js` and add `"hyper-samewd"` to `plugins` list manually.
+
 ## Config Options
 
 Currently the only option supported is `initialWorkingDirectory`. This allows you to set the initial directory when opening hyper for the first time.

--- a/index.js
+++ b/index.js
@@ -9,32 +9,30 @@ const setCwd = async (dispatch, pid) => {
     });
 }
 
-let config;
-exports.middleware = (store) => (next) => async (action) => {
+let hyperwdConfig;
+exports.middleware = ({ getState, dispatch }) => (next) => async (action) => {
     switch (action.type) {
         case 'CONFIG_RELOAD':
-        case 'CONFIG_LOAD':
-            config = action.config.hyperwd || {};
+        case 'CONFIG_LOAD': {
+            hyperwdConfig = action.config.hyperwd || {};
+            break;
+        }
         case 'SESSION_REQUEST':
         case 'TERM_GROUP_REQUEST': {
-            const { activeUid, sessions } = store.getState().sessions;
+            const { activeUid, sessions } = getState().sessions;
             if (activeUid) {
-                await setCwd(store.dispatch, sessions[activeUid].pid);
+                await setCwd(dispatch, sessions[activeUid].pid);
             }
             break;
         }
         case 'INIT':
-            if (config.initialWorkingDirectory) {
-                store.dispatch({
+            if (hyperwdConfig.initialWorkingDirectory) {
+                dispatch({
                     type: 'SESSION_SET_CWD',
-                    cwd: config.initialWorkingDirectory,
+                    cwd: hyperwdConfig.initialWorkingDirectory,
                 });
-            }     
-        default:
+            }
             break;
     }
-
     next(action);
 };
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "hyper-samewd",
+  "version": "1.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "pid-cwd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pid-cwd/-/pid-cwd-1.1.1.tgz",
+      "integrity": "sha512-cdIXKtoyjiVrMdz6j1bnqNME0L/e3wYZNZwnSTbcDqdZtky0AFh3YOky6KT7KXBgLmnm6K2LFF3zwOFjD6uvYw=="
+    }
+  }
+}


### PR DESCRIPTION
Added instruction to new users, of `hypersamewd`, ... and new users of hyper enviroment. (Previously I tired to install `hypersamewd` instead of `hyper-samewd`)

Also refactored some code, if you dont mind. 
And i think after `CONFIG` cases should be `break;`, so on reload hyper don't have to change folder from same to same.